### PR TITLE
Upgrade: hercule to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "drafter": "^1.1.0",
     "fury-adapter-swagger": "^0.9.6",
-    "hercule": "^3.2.2",
+    "hercule": "^4.0.0",
     "lodash.defaults": "^4.2.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ function parse(apiDescription, options={}, done) {
       source: options.filename
     };
 
-    transcludeString(apiDescription, herculeOptions, (err, transcluded, sources, sourcemap) => {
+    transcludeString(apiDescription, herculeOptions, (err, transcluded, sourcemap) => {
       drafter.parse(transcluded, {exportSourcemap: true}, (err, parsed) => {
         if (err) return done(err);
 


### PR DESCRIPTION
Only one API change that impacts `mateo`:

- removed `sources` from callback because sources are available via the `sourcemap`